### PR TITLE
Add raw_message_delivery option to queue subscriptions

### DIFF
--- a/lib/ex_aws_configurator/queue.ex
+++ b/lib/ex_aws_configurator/queue.ex
@@ -14,10 +14,14 @@ defmodule ExAwsConfigurator.QueueOptions do
   @type queue_options :: [
           max_receive_count: integer(),
           dead_letter_queue: boolean(),
-          dead_letter_queue_suffix: binary()
+          dead_letter_queue_suffix: binary(),
+          raw_message_delivery: boolean()
         ]
 
-  defstruct max_receive_count: 7, dead_letter_queue: true, dead_letter_queue_suffix: "_failures"
+  defstruct max_receive_count: 7,
+            dead_letter_queue: true,
+            dead_letter_queue_suffix: "_failures",
+            raw_message_delivery: false
 end
 
 defmodule ExAwsConfigurator.Queue do

--- a/test/ex_aws_configurator/sqs_test.exs
+++ b/test/ex_aws_configurator/sqs_test.exs
@@ -11,10 +11,12 @@ defmodule ExAwsConfigurator.SQSTest do
     add_queue_to_config(build(:queue_config, name: :queue_name))
     add_queue_to_config(%{queue_min_config: %{}})
     add_topic_to_config(build(:topic_config, name: :topic_name))
+    add_queue_to_config(build(:queue_config, name: :raw_queue, raw_message_delivery: true))
 
     SQS.create_queue(:queue_min_config)
     SQS.create_queue(:queue_name)
     SNS.create_topic(:topic_name)
+    SQS.create_queue(:raw_queue)
 
     add_queue_to_config(build(:queue_config, name: :non_created_queue))
   end
@@ -38,6 +40,10 @@ defmodule ExAwsConfigurator.SQSTest do
   describe "subscribe/2" do
     test "subscribe queue to an topic when is atom and with valid configuration" do
       assert {:ok, %{status_code: 200}} = SQS.subscribe(:queue_name, :topic_name)
+    end
+
+    test "subscribe queue to an topic when raw_message_delivery is true" do
+      assert {:ok, %{status_code: 200}} = SQS.subscribe(:raw_queue, :topic_name)
     end
 
     test "raise when tries to subscribe a queue without queue configuration" do

--- a/test/support/config_factory.ex
+++ b/test/support/config_factory.ex
@@ -13,12 +13,14 @@ defmodule ExAwsConfigurator.Factory.Config do
 
       def queue_config_factory(attrs) do
         name = Map.get(attrs, :name, :an_queue)
+        raw_message_delivery = Map.get(attrs, :raw_message_delivery, false)
 
         queue_config =
           %{
             environment: "test",
             prefix: "prefix",
             region: "us-east-1",
+            options: [raw_message_delivery: raw_message_delivery],
             topics: []
           }
           |> merge_attributes(attrs)


### PR DESCRIPTION
We need to add this option in subscription to not broke existing queues in our projects tha use this attribute in subscription.

For mor details and undestand what the `raw_message_delivery` option do see this [documentation](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html).