### PR TITLE
Allow creation of FIFO queues

### DIFF
--- a/lib/ex_aws_configurator/queue.ex
+++ b/lib/ex_aws_configurator/queue.ex
@@ -1,9 +1,9 @@
 defmodule ExAwsConfigurator.QueueAttributes do
   @type t :: ExAws.SQS.queue_attributes()
 
-  defstruct content_based_deduplication: false,
+  defstruct content_based_deduplication: nil,
             delay_seconds: 0,
-            fifo_queue: false,
+            fifo_queue: nil,
             maximum_message_size: 262_144,
             message_retention_period: 1_209_600,
             receive_message_wait_time_seconds: 0,

--- a/lib/ex_aws_configurator/sqs.ex
+++ b/lib/ex_aws_configurator/sqs.ex
@@ -6,6 +6,7 @@ defmodule ExAwsConfigurator.SQS do
 
   @raw_message_delivery "raw_message_delivery"
   @fifo_suffix ".fifo"
+  @fifo_attributes [:content_based_deduplication, :fifo_queue]
 
   @doc """
   Create an sqs queue based on ex_aws_configurator configuration, that method do NOT subscribe on any topic
@@ -199,7 +200,7 @@ defmodule ExAwsConfigurator.SQS do
     attributes =
       queue.attributes
       |> Map.from_struct()
-      |> Enum.reject(&is_nil/1)
+      |> Enum.reject(fn {key, value} -> key in @fifo_attributes and is_nil(value) end)
 
     full_name
     |> SQS.create_queue(attributes, tags)

--- a/test/ex_aws_configurator/sqs_test.exs
+++ b/test/ex_aws_configurator/sqs_test.exs
@@ -25,11 +25,9 @@ defmodule ExAwsConfigurator.SQSTest do
       build(:queue_config, name: :without_failures_queue, dead_letter_queue: false)
     )
 
-    SQS.create_queue(:queue_min_config)
     SQS.create_queue(:queue_name)
     SNS.create_topic(:topic_name)
     SQS.create_queue(:raw_queue)
-    SQS.create_queue(:"queue.fifo")
 
     add_queue_to_config(build(:queue_config, name: :non_created_queue))
   end

--- a/test/support/config_factory.ex
+++ b/test/support/config_factory.ex
@@ -15,26 +15,18 @@ defmodule ExAwsConfigurator.Factory.Config do
         name = Map.get(attrs, :name, :an_queue)
         raw_message_delivery = Map.get(attrs, :raw_message_delivery, false)
         dead_letter_queue = Map.get(attrs, :dead_letter_queue, true)
-        fifo_queue = Map.get(attrs, :fifo_queue, false)
-        content_based_deduplication = Map.get(attrs, :content_based_deduplication, false)
 
-        queue_config =
-          %{
-            environment: "test",
-            prefix: "prefix",
-            region: "us-east-1",
-            options: [
-              raw_message_delivery: raw_message_delivery,
-              dead_letter_queue: dead_letter_queue
-            ],
-            attributes: [
-              content_based_deduplication: content_based_deduplication,
-              fifo_queue: fifo_queue
-            ],
-            topics: []
-          }
-          |> merge_attributes(attrs)
-          |> Map.delete(:name)
+        queue_config = %{
+          environment: "test",
+          prefix: "prefix",
+          region: "us-east-1",
+          options: [
+            raw_message_delivery: raw_message_delivery,
+            dead_letter_queue: dead_letter_queue
+          ],
+          attributes: build_fifo_queue_attributes(attrs),
+          topics: []
+        }
 
         %{name => queue_config}
       end
@@ -53,6 +45,15 @@ defmodule ExAwsConfigurator.Factory.Config do
 
         %{name => topic_config}
       end
+
+      defp build_fifo_queue_attributes(%{fifo_queue: true}) do
+        [
+          content_based_deduplication: true,
+          fifo_queue: true
+        ]
+      end
+
+      defp build_fifo_queue_attributes(_attrs), do: []
     end
   end
 end


### PR DESCRIPTION
Adding support for a queue, and its dead letter queue, to be created as FIFO.
Also allow the `content_based_deduplication` boolean attribute to be set in order to avoid duplicate messages to be introduced in the queue.

**Additional information**
I also tried to create a FIFO topic to test the new queue, but apparently ExAws doesn't allow a topic to be created that way.

![image](https://user-images.githubusercontent.com/8454810/138294912-7f51e1b2-c5a1-41d8-b0d9-11dec6c34d81.png)

and setting the `content_based_deduplication` and `fifo_topic` post creation doesn't seem to be supported either

![image](https://user-images.githubusercontent.com/8454810/138295099-9b7e6a4d-c9cd-4c2c-8b0b-7d294ea02eb1.png)
![image](https://user-images.githubusercontent.com/8454810/138295158-c85b2d98-c63d-45ef-9ab3-be9a09b56df5.png)

This might be a problem whenever we need to create a FIFO topic using the lib