### PR TITLE
feat: add configurable separator to Topic and Queue

### DIFF
--- a/lib/ex_aws_configurator/queue.ex
+++ b/lib/ex_aws_configurator/queue.ex
@@ -38,6 +38,7 @@ defmodule ExAwsConfigurator.Queue do
           region: binary(),
           environment: binary(),
           prefix: binary(),
+          separator: binary(),
           attributes: QueueAttributes,
           options: QueueOptions,
           topics: [Topic]
@@ -47,6 +48,7 @@ defmodule ExAwsConfigurator.Queue do
             environment: nil,
             region: nil,
             prefix: nil,
+            separator: "_",
             attributes: %QueueAttributes{},
             options: %QueueOptions{},
             topics: []
@@ -56,7 +58,7 @@ defmodule ExAwsConfigurator.Queue do
   def full_name(%__MODULE__{} = queue) do
     [queue.prefix, queue.environment, queue.name]
     |> Enum.filter(&(!is_nil(&1)))
-    |> Enum.join("_")
+    |> Enum.join(queue.separator)
   end
 
   @doc "get queue url"

--- a/lib/ex_aws_configurator/topic.ex
+++ b/lib/ex_aws_configurator/topic.ex
@@ -14,6 +14,7 @@ defmodule ExAwsConfigurator.Topic do
           region: binary(),
           environment: binary(),
           prefix: binary(),
+          separator: binary(),
           attributes: TopicAttributes
         }
 
@@ -21,6 +22,7 @@ defmodule ExAwsConfigurator.Topic do
             environment: nil,
             region: nil,
             prefix: nil,
+            separator: "_",
             attributes: %TopicAttributes{}
 
   @doc "get topic arn"
@@ -35,6 +37,6 @@ defmodule ExAwsConfigurator.Topic do
   def full_name(%__MODULE__{} = topic) do
     [topic.prefix, topic.environment, topic.name]
     |> Enum.filter(&(!is_nil(&1)))
-    |> Enum.join("_")
+    |> Enum.join(topic.separator)
   end
 end

--- a/test/ex_aws_configurator/queue_test.exs
+++ b/test/ex_aws_configurator/queue_test.exs
@@ -27,6 +27,11 @@ defmodule ExAwsConfigurator.QueueTest do
     test "build full_name from queue", %{queue: queue} do
       assert "pref_env_topic" = Queue.full_name(queue)
     end
+
+    test "uses custom separator when configured", %{queue: queue} do
+      queue = %{queue | separator: "-"}
+      assert "pref-env-topic" = Queue.full_name(queue)
+    end
   end
 
   describe "url/1" do

--- a/test/ex_aws_configurator/topic_test.exs
+++ b/test/ex_aws_configurator/topic_test.exs
@@ -27,5 +27,10 @@ defmodule ExAwsConfigurator.TopicTest do
     test "build full_name from topic", %{topic: topic} do
       assert "pref_env_topic" = Topic.full_name(topic)
     end
+
+    test "uses custom separator when configured", %{topic: topic} do
+      topic = %{topic | separator: "-"}
+      assert "pref-env-topic" = Topic.full_name(topic)
+    end
   end
 end


### PR DESCRIPTION
# Motivação 💪
O separador entre `prefix`, `environment` e `name` era fixo (`_`), impedindo nomes de tópicos/filas com convenção de hífens (ex: `tf-alligator-production-promotion-changed`).

# Solução 🔧
Adicionado campo `separator` (default `"_"`) aos structs `Topic` e `Queue`. O `full_name/1` de ambos passa a usar o separador configurado em vez do underscore fixo.

A mudança é totalmente backward-compatible: projetos existentes sem `separator` configurado continuam gerando nomes idênticos.

# Como testar 👮‍♂️
```elixir
# comportamento padrão — sem quebra
topic = %ExAwsConfigurator.Topic{prefix: "tf", environment: "prod", name: "my-topic"}
ExAwsConfigurator.Topic.full_name(topic)
# => "tf_prod_my-topic"

# com separador personalizado
topic = %{topic | separator: "-"}
ExAwsConfigurator.Topic.full_name(topic)
# => "tf-prod-my-topic"
```

Ou via `mix test`.

# Imagens/GIFs
Não se aplica.